### PR TITLE
Update to wi-gatk

### DIFF
--- a/WS245/WS245.dict
+++ b/WS245/WS245.dict
@@ -1,8 +1,0 @@
-@HD	VN:1.0	SO:unsorted
-@SQ	SN:I	LN:15072434	M5:185711aa389cf8d9302ad2ab07bd31e0	UR:file:///Users/dancook/coding/andersen_lab/wi-gatk/WS245/WS245.fa
-@SQ	SN:II	LN:15279421	M5:9e7e67d1e51cdb31791deab89dc31550	UR:file:///Users/dancook/coding/andersen_lab/wi-gatk/WS245/WS245.fa
-@SQ	SN:III	LN:13783801	M5:c0f1a58d2bf6ff6a16617839bbc5fe52	UR:file:///Users/dancook/coding/andersen_lab/wi-gatk/WS245/WS245.fa
-@SQ	SN:IV	LN:17493829	M5:2156ab555e19afd8a0ca5aba82fb2a2a	UR:file:///Users/dancook/coding/andersen_lab/wi-gatk/WS245/WS245.fa
-@SQ	SN:V	LN:20924180	M5:ffaf018f42f95375d2af6dcd402fef69	UR:file:///Users/dancook/coding/andersen_lab/wi-gatk/WS245/WS245.fa
-@SQ	SN:X	LN:17718942	M5:dae3e9ec047e8147337b550dd8564d0b	UR:file:///Users/dancook/coding/andersen_lab/wi-gatk/WS245/WS245.fa
-@SQ	SN:MtDNA	LN:13794	M5:199e147d502d88e45047413dc83c039c	UR:file:///Users/dancook/coding/andersen_lab/wi-gatk/WS245/WS245.fa

--- a/conf/quest.config
+++ b/conf/quest.config
@@ -3,6 +3,8 @@
 */
 process {
 
+    conda = "/projects/b1059/software/conda_envs/gatk-nf_env"
+
     withLabel: xs {
         cpus = 1
         memory = 1.GB
@@ -31,39 +33,14 @@ process {
 }
 
 params {
-            
-    // genome
-    genome = "WS245"
-    reference = "/projects/b1059/data/genomes/c_elegans/${genome}/${genome}.fa.gz"
+	
+	genome="WS276"
+	
+	reference = "/projects/b1059/data/genomes/c_elegans/${genome}/c_elegans.PRJNA13758.${genome}.genomic.fa.gz"
 
-    tmpdir = "/projects/b1042/AndersenLab/tmp"
-    debug = false
-    
-    mode = "run"
-    base_input_dir = "/projects/b1059/workflows/diverged_regions-nf/input_files"
-    // genome
-    genome = "WS245"
-    reference = "/projects/b1059/data/genomes/c_elegans/${genome}/${genome}.fa.gz"
-    gff = "/${base_input_dir}bin/ce.gff3.gz"
-    strains = "/projects/b1059/projects/Ye/strain_identify/strain_coverage/reference_strain_list.tsv"
-    interval_bed = "${base_input_dir}bin/Split_Genome_full.bed"
-    // variant filters
-    missing = 0.95
-    annotation_reference = "WS263"
-    bamdir = "/projects/b1059/data/alignments/WI/strain/"
-    min_depth = 5
-    qual = 30.0
-    mapping_quality = 30.0
-    strand_odds_ratio = 5.0
-    dv_dp = 0.5
-    quality_by_depth = 5.0
-    min_depth_individual = 1
-    cores = 6
-    fisherstrand = 50.0
-    readbias = -5.0
-    
+	annotation_reference = "WS276"
+
+	annotation_gff = "/projects/b1059/data/genomes/c_elegans/${genome}/c_elegans.PRJNA13758.${genome}.annotations.CSQ.gff3"
+
 }
 
-singularity {
-    enabled = true
-}

--- a/conf/quest.config
+++ b/conf/quest.config
@@ -11,17 +11,17 @@ process {
     }
 
     withLabel: sm {
-        cpus = 2
+        cpus = 1
         memory = 4.GB
     }
 
     withLabel: md {
-        cpus = 8
+        cpus = 2
         memory = 8.GB
     }
 
     withLabel: lg {
-        cpus = 10
+        cpus = 4
         memory = 20.GB
     }
 
@@ -42,5 +42,12 @@ params {
 
 	annotation_gff = "/projects/b1059/data/genomes/c_elegans/${genome}/c_elegans.PRJNA13758.${genome}.annotations.CSQ.gff3"
 
+}
+
+
+executor {
+
+    queueSize=500
+    
 }
 

--- a/main.nf
+++ b/main.nf
@@ -230,8 +230,6 @@ process call_variants_individual {
     """
         gatk HaplotypeCaller --java-options "-Xmx${task.memory.toGiga()}g -Xms1g -XX:ConcGCThreads=${task.cpus}" \\
             --emit-ref-confidence GVCF \\
-            --max-genotype-count 3000 \\
-            --max-alternate-alleles 100 \\
             --annotation DepthPerAlleleBySample \\
             --annotation Coverage \\
             --annotation GenotypeSummaries \\

--- a/main.nf
+++ b/main.nf
@@ -444,8 +444,8 @@ process soft_filter {
 
 
         # Apply high missing and high heterozygosity filters
-        bcftools filter --threads ${task.cpus} --soft-filter='high_missing' --mode +x --include 'F_MISSING  <= ${params.high_missing}' ad_dp.filtered_no_call.vcf.gz |\\
-        bcftools filter --threads ${task.cpus} --soft-filter='high_heterozygosity' --mode +x --include '( COUNT(GT="het") / N_SAMPLES ) <= ${params.high_heterozygosity}' -O z > WI.${date}.soft-filter.vcf.gz
+        bcftools filter --threads ${task.cpus} --soft-filter='high_missing' --mode + --include 'F_MISSING  <= ${params.high_missing}' ad_dp.filtered_no_call.vcf.gz |\\
+        bcftools filter --threads ${task.cpus} --soft-filter='high_heterozygosity' --mode + --include '( COUNT(GT="het") / N_SAMPLES ) <= ${params.high_heterozygosity}' -O z > WI.${date}.soft-filter.vcf.gz
 
         bcftools index WI.${date}.soft-filter.vcf.gz
         bcftools index --tbi WI.${date}.soft-filter.vcf.gz

--- a/main.nf
+++ b/main.nf
@@ -175,9 +175,6 @@ workflow {
     hard_filter.out.vcf | somalier_extract
     somalier_extract.out.collect().view() | somalier_relate
 
-    // Tajima BED File
-    hard_filter.out.vcf | tajima_bed
-
     // MultiQC Report
     soft_filter.out.soft_vcf_stats.concat(
         hard_filter.out.hard_vcf_stats,
@@ -627,25 +624,6 @@ process calculate_gtcheck {
         } > gtcheck.${date}.tsv
     """
 }
-
-process tajima_bed {
-
-    conda "vcfkit=0.1.6"
-
-    publishDir "${params.output}/popgen", mode: 'copy'
-
-    input:
-        tuple path(vcf), path(vcf_index)
-    output:
-        set file("WI.${date}.tajima.bed.gz"), file("WI.${date}.tajima.bed.gz.tbi")
-
-    """
-        vk tajima --no-header 100000 10000 ${vcf} | bgzip > WI.${date}.tajima.bed.gz
-        tabix WI.${date}.tajima.bed.gz
-    """
-
-}
-
 
 process multiqc_report {
 

--- a/main.nf
+++ b/main.nf
@@ -20,33 +20,23 @@ assert System.getenv("NXF_VER") == "20.01.0-rc1"
 date = new Date().format( 'yyyyMMdd' )
 params.debug = false
 params.email = ""
-params.reference = "${workflow.projectDir}/WS245/WS245.fa.gz"
-params.annotation_reference = "WS263"
-params.annotation_gff = "${workflow.projectDir}/genome/PRJNA13758_WS274/Caenorhabditis_elegans.WBcel235.99.gff3.gz"
+params.reference = ""
+params.annotation_reference = ""  // this is genome version for snpeff
+params.annotation_gff = ""
 reference_uncompressed = file(params.reference.replace(".gz", ""), checkIfExists: true)
 parse_conda_software = file("${workflow.projectDir}/scripts/parse_conda_software.awk", checkIfExists: true)
+params.help = false
 
 // Debug
 if (params.debug.toString() == "true") {
     params.output = "release-${date}-debug"
     params.sample_sheet = "${workflow.projectDir}/test_data/sample_sheet.tsv"
-    params.bamdir = "${workflow.projectDir}/test_data"
 } else {
     // The strain sheet that used for 'production' is located in the root of the git repo
-    params.output = "alignment-${date}"
-    params.sample_sheet = "sample_sheet.tsv"
+    params.output = "WI-${date}"
+    params.sample_sheet = "${workflow.projectDir}/sample_sheet.tsv"
 }
 
-/*
-    Config
-*/
-
-// defaults
-params.help                   = false
-params.bamdir                 = null
-params.out_base               = null
-params.gff                    = null
-params.strains                = false
 
 // Variant Filtering
 params.min_depth = 5
@@ -58,8 +48,6 @@ params.fisherstrand = 50.0
 params.high_missing = 0.95
 params.high_heterozygosity = 0.10
 
-
-params.out                    = "${date}-${params.out_base}"
 
 def log_summary() {
 
@@ -115,18 +103,15 @@ if (workflow.profile == "") {
     exit 1
 }
 
-strains = params.strains ? params.strains.split(",") : false
 
 // Read sample sheet
 sample_sheet = Channel.fromPath(params.sample_sheet, checkIfExists: true)
                        .ifEmpty { exit 1, "sample sheet not found" }
                        .splitCsv(header:true, sep: "\t")
                       .map { row -> [row.strain,
-                                     row.reference_strain == "TRUE",
-                                     file("${params.bamdir}/${row.strain}.bam", checkExists: true),
-                                     file("${params.bamdir}/${row.strain}.bam.bai", checkExists: true)] }
-                      .distinct()
-                      .filter { params.strains ? it[0] in strains : true }
+                                     file("${row.bam}", checkExists: true),
+                                     file("${row.bai}", checkExists: true)] }
+
 
 workflow {
 
@@ -141,7 +126,7 @@ workflow {
     sample_sheet.combine(contigs) | call_variants_individual
 
     call_variants_individual.out.groupTuple()
-                                .map { strain, ref_strain, vcf -> [strain, ref_strain[0], vcf]}
+                                .map { strain, vcf -> [strain, vcf]}
                                 .combine(get_contigs.out) | \
                                 concat_strain_gvcfs
     
@@ -171,10 +156,6 @@ workflow {
     // Extract SNPeff severity tracks
     mod_tracks = Channel.from(["LOW", "MODERATE", "HIGH", "MODIFIER"])
     soft_filter.out.soft_filter_vcf.spread(mod_tracks) | generate_severity_tracks
-
-    // Somalier
-    hard_filter.out.vcf | somalier_extract
-    somalier_extract.out.collect() | somalier_relate
 
     // MultiQC Report
     soft_filter.out.soft_vcf_stats.concat(
@@ -217,7 +198,7 @@ process get_contigs {
     label 'sm'
 
     input:
-        tuple strain, ref_strain, path(bam), path(bai)
+        tuple strain, path(bam), path(bai)
 
     output:
         path("contigs.txt")
@@ -241,10 +222,10 @@ process call_variants_individual {
     conda "gatk4=4.1.4.0"
 
     input:
-        tuple strain, ref_strain, path(bam), path(bai), val(region)
+        tuple strain, path(bam), path(bai), val(region)
 
     output:
-        tuple strain, ref_strain, path("${region}.g.vcf.gz")
+        tuple strain, path("${region}.g.vcf.gz")
 
     """
         gatk HaplotypeCaller --java-options "-Xmx${task.cpus}g -Xms1g" \\
@@ -288,7 +269,7 @@ process concat_strain_gvcfs {
     conda "bcftools=1.9"
 
     input:
-        tuple strain, ref_strain, path("*"), path(contigs)
+        tuple strain, path("*"), path(contigs)
 
     output:
         tuple path("${strain}.g.vcf.gz"), path("${strain}.g.vcf.gz.tbi")
@@ -381,7 +362,7 @@ process annotate_vcf {
 
     """
       bcftools view --threads=${task.cpus-1} ${contig}.vcf.gz | \\
-      bcftools csq -O v --fasta-ref ${params.reference} \\
+      bcftools csq -O v --fasta-ref ${reference_uncompressed} \\
                      --gff-annot ${file(params.annotation_gff, checkIfExists: true)} \\
                      --phase a | \\
       snpEff eff -csvStats ${contig}.${date}.snpeff.csv \\
@@ -407,6 +388,7 @@ process concatenate_vcf {
     label 'lg'
 
     conda 'bcftools=1.9'
+    publishDir "${params.output}/variation", mode: 'copy'
 
     input:
         tuple path("*"), path("contigs.txt")
@@ -441,14 +423,8 @@ process soft_filter {
         path "WI.${date}.soft-filter.vcf.gz.tbi"
         path "WI.${date}.soft-filter.stats.txt", emit: 'soft_vcf_stats'
 
-    script:
-        os='uname'.execute().text.strip() == "Darwin" ? "macos" : "linux"
-    """
-        function cleanup {
-            rm ad_dp.filtered.vcf.gz
-        }
-        trap cleanup EXIT
 
+    """
         gatk --java-options "-Xmx${task.memory.toGiga()-1}g -Xms${task.memory.toGiga()-2}g" \\
             VariantFiltration \\
             -R ${reference_uncompressed} \\
@@ -458,10 +434,8 @@ process soft_filter {
             --filter-expression "FS > ${params.fisherstrand}"          --filter-name "FS_fisherstrand" \\
             --filter-expression "QD < ${params.quality_by_depth}"      --filter-name "QD_quality_by_depth" \\
             --filter-expression "SOR > ${params.strand_odds_ratio}"    --filter-name "SOR_strand_odds_ratio" \\
-            -O /dev/stdout | \\
-            ad_dp_${os}
-        # ad_dp outputs a file called 'ad_dp.filtered.vcf.gz'
-  
+            -O ad_dp.filtered.vcf.gz
+
         # Apply high missing and high heterozygosity filters
         bcftools filter --soft-filter='high_missing' --mode +x --include 'F_MISSING  <= ${params.high_missing}' ad_dp.filtered.vcf.gz |\\
         bcftools filter --soft-filter='high_heterozygosity' --mode +x --include '( COUNT(GT="het") / N_SAMPLES ) <= ${params.high_heterozygosity}' -O z > WI.${date}.soft-filter.vcf.gz
@@ -493,27 +467,14 @@ process hard_filter {
 
 
     """
-        function cleanup {
-            # cleanup files on completion
-            rm I.vcf.gz II.vcf.gz III.vcf.gz IV.vcf.gz V.vcf.gz X.vcf.gz MtDNA.vcf.gz
-        }
-        #trap cleanup EXIT
+
         # Generate hard-filtered VCF
-        function generate_hard_filter {
-            bcftools view -m2 -M2 --trim-alt-alleles -O u --regions \${1} ${vcf} |\\
-            bcftools filter -O u --set-GTs . --exclude 'FORMAT/FT != "PASS"' |\\
-            bcftools filter -O u --exclude 'FILTER != "PASS"' |\\
-            bcftools view -O v --min-af 0.0000000000001 --max-af 0.999999999999 |\\
-            vcffixup - | \\
-            bcftools view -O z --trim-alt-alleles > \${1}.vcf.gz
-        }
-
-        export -f generate_hard_filter
-
-        parallel --verbose generate_hard_filter :::: ${contigs}
-
-        awk '{ print \$0 ".vcf.gz" }' ${contigs} > contig_set.tsv
-        bcftools concat  -O z --file-list contig_set.tsv > WI.${date}.hard-filter.vcf.gz
+        bcftools view -m2 -M2 --trim-alt-alleles -O u ${vcf} |\\
+        bcftools filter -O u --set-GTs . --exclude 'FORMAT/FT != "PASS"' |\\
+        bcftools filter -O u --exclude 'FILTER != "PASS"' |\\
+        bcftools view -O v --min-af 0.0000000000001 --max-af 0.999999999999 |\\
+        vcffixup - | \\
+        bcftools view -O z --trim-alt-alleles > WI.${date}.hard-filter.vcf.gz
 
         bcftools index WI.${date}.hard-filter.vcf.gz
         bcftools index --tbi WI.${date}.hard-filter.vcf.gz
@@ -570,42 +531,7 @@ process generate_strain_tsv_vcf {
 
 }
 
-process somalier_extract {
 
-    input:
-        tuple path(vcf), file(vcf_index)
-
-    output:
-        path("*.somalier")
-
-    container 'brentp/somalier:dev'
-
-    """
-        somalier extract --sites ${vcf} -f ${params.reference} ${vcf}
-    """
-
-}
-
-process somalier_relate {
-    
-    publishDir "${params.output}/somalier", mode: "copy"
-
-    input:
-        path("*.somalier")
-
-    output:
-        path("somalier.pairs.tsv")
-        path("somalier.html")
-        path("somalier.pairs.tsv")
-        path("somalier.samples.tsv")
-
-    container 'brentp/somalier:dev'
-
-    """
-        somalier relate *.somalier
-    """
-
-}
 
 process generate_severity_tracks {
     /*
@@ -634,7 +560,7 @@ process generate_severity_tracks {
         awk '\$0 !~ "^#" { print \$1 "\\t" (\$2 - 1) "\\t" (\$2)  "\\t" \$1 ":" \$2 "\\t0\\t+"  "\\t" \$2 - 1 "\\t" \$2 "\\t0\\t1\\t1\\t0" }' | \\
         bgzip  > ${date}.${severity}.bed.gz
         tabix -p bed ${date}.${severity}.bed.gz
-        fsize=\$(gzcat ${date}.${severity}.bed.gz | wc -c)
+        fsize=\$(zcat ${date}.${severity}.bed.gz | wc -c)
         if [ \${fsize} -lt 2000 ]; then
             exit 1
         fi;

--- a/main.nf
+++ b/main.nf
@@ -386,7 +386,6 @@ process concatenate_vcf {
     label 'lg'
 
     conda 'bcftools=1.9'
-    publishDir "${params.output}/variation", mode: 'copy'
 
     input:
         tuple path("*"), path("contigs.txt")
@@ -420,6 +419,7 @@ process soft_filter {
         tuple path("WI.${date}.soft-filter.vcf.gz"), path("WI.${date}.soft-filter.vcf.gz.csi"), emit: soft_filter_vcf
         path "WI.${date}.soft-filter.vcf.gz.tbi"
         path "WI.${date}.soft-filter.stats.txt", emit: 'soft_vcf_stats'
+        path "WI.${date}.soft-filter.filter_stats.txt"
 
 
     """
@@ -448,7 +448,10 @@ process soft_filter {
         bcftools index WI.${date}.soft-filter.vcf.gz
         bcftools index --tbi WI.${date}.soft-filter.vcf.gz
         bcftools stats --threads ${task.cpus} \\
-                        --verbose  WI.${date}.soft-filter.vcf.gz > WI.${date}.soft-filter.stats.txt
+                       -s- --verbose WI.${date}.soft-filter.vcf.gz > WI.${date}.soft-filter.stats.txt
+
+        bcftools query -f '%QUAL\t%INFO/QD\t%INFO/SOR\t%INFO/FS\t%FILTER\n' WI.${date}.soft-filter.vcf.gz > WI.${date}.soft-filter.filter_stats.txt
+
     """
 }
 
@@ -483,7 +486,7 @@ process hard_filter {
 
         bcftools index WI.${date}.hard-filter.vcf.gz
         bcftools index --tbi WI.${date}.hard-filter.vcf.gz
-        bcftools stats --verbose WI.${date}.hard-filter.vcf.gz > WI.${date}.hard-filter.stats.txt
+        bcftools stats -s- --verbose WI.${date}.hard-filter.vcf.gz > WI.${date}.hard-filter.stats.txt
     """
 }
 

--- a/scripts/setup_genome.sh
+++ b/scripts/setup_genome.sh
@@ -1,0 +1,16 @@
+# This script will download, index, and prep reference genomes.
+
+# Prep N2 reference genome
+RELEASE=WS274
+PROJECT=PRJNA13758
+
+mkdir -p "${PROJECT}.${RELEASE}" && cd "${PROJECT}.${RELEASE}"
+
+# Annotation file
+wget ftp://ftp.ensembl.org/pub/current_gff3/caenorhabditis_elegans/Caenorhabditis_elegans.WBcel235.99.gff3.gz
+
+# Download and prepare FASTA Genome
+wget "ftp://ftp.wormbase.org/pub/wormbase/species/c_elegans/${PROJECT}/sequence/genomic/c_elegans.${PROJECT}.${RELEASE}.genomic.fa.gz"
+
+bwa index c_elegans.${PROJECT}.${RELEASE}.genomic.fa.gz
+gunzip -kfc c_elegans.${PROJECT}.${RELEASE}.genomic.fa.gz > c_elegans.${PROJECT}.${RELEASE}.genomic.fa

--- a/test_data/sample_sheet.tsv
+++ b/test_data/sample_sheet.tsv
@@ -1,0 +1,15 @@
+strain	bam	bai
+AB1	/projects/b1059/projects/Dan/wi-gatk/test_data/AB1.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/AB1.bam.bai
+ECA243	/projects/b1059/projects/Dan/wi-gatk/test_data/ECA243.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/ECA243.bam.bai
+ECA718	/projects/b1059/projects/Dan/wi-gatk/test_data/ECA718.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/ECA718.bam.bai
+ED3046	/projects/b1059/projects/Dan/wi-gatk/test_data/ED3046.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/ED3046.bam.bai
+JU1511	/projects/b1059/projects/Dan/wi-gatk/test_data/JU1511.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/JU1511.bam.bai
+JU2234	/projects/b1059/projects/Dan/wi-gatk/test_data/JU2234.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/JU2234.bam.bai
+JU3167	/projects/b1059/projects/Dan/wi-gatk/test_data/JU3167.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/JU3167.bam.bai
+LSJ1	/projects/b1059/projects/Dan/wi-gatk/test_data/LSJ1.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/LSJ1.bam.bai
+MY2338	/projects/b1059/projects/Dan/wi-gatk/test_data/MY2338.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/MY2338.bam.bai
+MY2693	/projects/b1059/projects/Dan/wi-gatk/test_data/MY2693.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/MY2693.bam.bai
+NIC262	/projects/b1059/projects/Dan/wi-gatk/test_data/NIC262.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/NIC262.bam.bai
+PB303	/projects/b1059/projects/Dan/wi-gatk/test_data/PB303.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/PB303.bam.bai
+QX1213	/projects/b1059/projects/Dan/wi-gatk/test_data/QX1213.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/QX1213.bam.bai
+WN2065	/projects/b1059/projects/Dan/wi-gatk/test_data/WN2065.bam	/projects/b1059/projects/Dan/wi-gatk/test_data/WN2065.bam.bai


### PR DESCRIPTION
Here are the updates:

1. GATK VariantFiltration on the FORMAT (genotype) field with 
`--genotype-filter-expression "DP < ${params.min_depth}"    --genotype-filter-name "DP_min_depth"` will only add a FT field with `PASS` or `DP_min_depth` for variant positions that has at least 1 strain failed the filter. See here: https://gatk.broadinstitute.org/hc/en-us/articles/360035891191-VariantFiltration-FT-tag
In other words, for variant positions that all strains pass the filter, there will not be a `PASS` added. This creates a challenge for `bcftools filter -O u --set-GTs . --exclude 'FORMAT/FT != "PASS"'` in the hard filter step.
So I added `gatk SelectVariants --set-filtered-gt-to-nocall` to change genotype in failed positions to `./.` in 
https://gatk.broadinstitute.org/hc/en-us/articles/360035531012--How-to-Filter-on-genotype-using-VariantFiltration
Note this step should happen before filtering for `high_missing`. 
`ded49b8`

2. bcftools softfilter with `--mode +` will append new filter names to the FILTER field for sites that fail, with `--mode x` will reset FILTER field to PASS for sites that pass this current filter. http://samtools.github.io/bcftools/bcftools.html#filter
Changed `--mode +x` to `--mode +` for high_missing and high_heterozogysity 
`dbbdcdc`

3. Removed `--max-genotype-count 3000  --max-alternate-alleles 100` from single sample `gatk HaplotypeCaller` step. May consider adding this to `gatk GenotypeGVCFs` step but increasing these values will increase computation cost exponentially https://gatk.broadinstitute.org/hc/en-us/articles/360036348452-GenotypeGVCFs#--max-alternate-alleles 
`9a99b43`

4. Modify outputs associated with making the report:
	- No longer write out annotated.vcf which I added earlier for troubleshooting purpose.
	- Add option `-s-` to `bcftools stats` to write out per sample stats
	- Write out the `'%QUAL\t%INFO/QD\t%INFO/SOR\t%INFO/FS\t%FILTER\n'` fields of soft-filtered vcf for the report. 
`0eda098`

5. remove WS245 genome folder that is no longer used.
`da9f6da`
