### PR TITLE
Restructure

### DIFF
--- a/conf/quest.config
+++ b/conf/quest.config
@@ -33,7 +33,7 @@ process {
 
         executor = 'slurm'
         queue = 'b1059'
-        clusterOptions = '-A b1059 -t 1-00:00:00 -e errlog.txt'
+        clusterOptions = '-A b1059 -t 14-00:00:00 -e errlog.txt'
     }
 
     errorStrategy='retry'

--- a/conf/quest.config
+++ b/conf/quest.config
@@ -33,7 +33,7 @@ process {
 
         executor = 'slurm'
         queue = 'b1059'
-        clusterOptions = '-A b1059 -t 14-00:00:00 -e errlog.txt'
+        clusterOptions = '-A b1059 -t 1-00:00:00 -e errlog.txt'
     }
 
     errorStrategy='retry'
@@ -52,12 +52,6 @@ params {
     /* Keep these static ~ They should not need to be updated */
     reference_dir = "${reference_base}/${species}/${project}/${ws_build}"
     reference = "${reference_dir}/${species}.${project}.${ws_build}.genome.fa.gz"
-    snpeff_reference = "${species}.${project}.${ws_build}"
-    snpeff_dir = "${reference_dir}/snpeff"
-    snpeff_config = "${reference_dir}/snpeff/snpEff.config"
-    csq_gff = "${reference_dir}/csq/${species}.${project}.${ws_build}.csq.gff3.gz"
-    dust_bed = "${reference_dir}/lcr/${species}.${project}.${ws_build}.dust.bed.gz"
-    repeat_masker_bed = "${reference_dir}/lcr/${species}.${project}.${ws_build}.repeat_masker.bed.gz"
 
 
 }

--- a/main.nf
+++ b/main.nf
@@ -158,8 +158,7 @@ workflow {
 
 
     // Combine VCF and filter
-    vcfs = genotype_cohort_gvcf_db.out.collect().map { [it] }.combine(get_contigs.out)
-    vcfs | concatenate_vcf
+    genotype_cohort_gvcf_db.out.collect() | concatenate_vcf
     concatenate_vcf.out.vcf | soft_filter
     soft_filter.out.soft_filter_vcf.combine(get_contigs.out) | hard_filter
 
@@ -317,7 +316,7 @@ process genotype_cohort_gvcf_db {
         tuple val(contig), file("${contig}.db")
 
     output:
-        tuple val(contig), file("${contig}_cohort.bcf"), file("${contig}_cohort.bcf.csi")
+        tuple file("${contig}_cohort.bcf"), file("${contig}_cohort.bcf.csi")
 
 
     /*
@@ -352,21 +351,21 @@ process genotype_cohort_gvcf_db {
 
 
 /*===============================================
-~ ~ ~ > *   Concatenate Annotated VCFs  * < ~ ~ ~
+~ ~ ~ > *   Concatenate VCFs  * < ~ ~ ~
 ===============================================*/
 
 process concatenate_vcf {
 
     label 'lg'
 
-    input:
-        tuple path("*"), path("contigs.txt")
+    input: 
+      path("*")
 
     output:
-        tuple path("WI.annotated.vcf.gz"), path("WI.annotated.vcf.gz.tbi"), emit: 'vcf'
+        tuple path("WI.raw.vcf.gz"), path("WI.raw.vcf.gz.tbi"), emit: 'vcf'
 
     """
-        awk '{ print \$0 "_cohort.bcf" }' contigs.txt > contig_set.tsv
+        ls *_cohort.bcf > contig_set.tsv
         bcftools concat  -O z --file-list contig_set.tsv > WI.raw.vcf.gz
         bcftools index --tbi WI.raw.vcf.gz
     """

--- a/main.nf
+++ b/main.nf
@@ -4,6 +4,7 @@
     Authors:
     - Stefan Zdraljevic
     - Daniel Cook <danielecook@gmail.com>
+    - Dan Lu
 */
 nextflow.preview.dsl=2
 
@@ -18,8 +19,6 @@ nextflow.preview.dsl=2
 */
 
 date = new Date().format( 'yyyyMMdd' )
-params.debug = false
-params.help = false
 params.bam_location = "" // Use this to specify the directory for bams
 params.mito_name = "MtDNA" // Name of contig to skip het polarization
 
@@ -29,16 +28,14 @@ params.reference = ""
 reference = file(params.reference, checkIfExists: true)
 
 // Debug
-if (params.debug.toString() == "true") {
+if (params.debug) {
     params.output = "release-debug"
     params.sample_sheet = "${workflow.projectDir}/test_data/sample_sheet.tsv"
     params.bam_location = "${workflow.projectDir}" // Use this to specify the directory for bams
-//    params.cendr = true  // Whether write out strain vcf and severity tracks which is likely only used by cendr
 } else {
     // The strain sheet that used for 'production' is located in the root of the git repo
     params.output = "WI-${date}"
     params.sample_sheet = "${workflow.projectDir}/sample_sheet.tsv"
-//    params.cendr = false
 }
 
 
@@ -65,38 +62,35 @@ def log_summary() {
 
 out += """
 
-    parameters               description                 Set/Default
-    ==========               ===========                 ========================
-    output                   Release Directory           ${params.output}
-    sample_sheet             sample sheet                ${params.sample_sheet}
-    bam_location             Directory of bam files      ${params.bam_location}
-    reference                Reference Genome            ${reference}
-    mito_name                Contig not to polarize het  ${params.mito_name}
-    cendr                    Write out single-strain vcf ${params.cendr}
-    username                                             ${"whoami".execute().in.text}
+To run the pipeline:
 
-    Nextflow Run
-    ---------------
-    ${workflow.commandLine}
-    run name                                             ${workflow.runName}
-    scriptID                                             ${workflow.scriptId}
-    git commit                                           ${workflow.commitId}
-    container                                            ${workflow.container}
+nextflow main.nf --debug
+nextflow main.nf --sample_sheet=/path/sample_sheet_GATK.tsv --bam_location=/projects/b1059/workflows/alignment-nf/
+
+    parameters                 description                           Set/Default
+    ==========                 ===========                           ========================
+    --debug                    Use --debug to indicate debug mode    ${params.debug}
+    --output                   Release Directory                     ${params.output}
+    --sample_sheet             Sample sheet                          ${params.sample_sheet}
+    --bam_location             Directory of bam files                ${params.bam_location}
+    --reference                Reference Genome                      ${params.reference}
+    --mito_name                Contig not to polarize hetero sites   ${params.mito_name}
+    --username                                                       ${"whoami".execute().in.text}
 
     Reference Genome
-    ---------------
-    reference_base          location of ref genomes      ${params.reference_base}
-    species/project/build                                ${params.species} / ${params.project} / ${params.ws_build}
+    --------------- 
+    --reference_base           Location of ref genomes               ${params.reference_base}
+    --species/project/build    These 4 params form --reference       ${params.species} / ${params.project} / ${params.ws_build}
 
     Variant Filters         
     ---------------           
-    min_depth                Minimum variant depth       ${params.min_depth}
-    qual                     Variant QUAL score          ${params.qual}
-    strand_odds_ratio        SOR_strand_odds_ratio       ${params.strand_odds_ratio} 
-    quality_by_depth         QD_quality_by_depth         ${params.quality_by_depth} 
-    fisherstrand             FS_fisher_strand            ${params.fisherstrand}
-    missing_max              % missing genotypes         ${params.high_missing}
-    heterozygosity_max       % max heterozygosity        ${params.high_heterozygosity}
+    --min_depth                Minimum variant depth                 ${params.min_depth}
+    --qual                     Variant QUAL score                    ${params.qual}
+    --strand_odds_ratio        SOR_strand_odds_ratio                 ${params.strand_odds_ratio} 
+    --quality_by_depth         QD_quality_by_depth                   ${params.quality_by_depth} 
+    --fisherstrand             FS_fisher_strand                      ${params.fisherstrand}
+    --high_missing             Max % missing genotypes               ${params.high_missing}
+    --high_heterozygosity      Max % max heterozygosity              ${params.high_heterozygosity}
 
 ---
 """
@@ -106,11 +100,6 @@ out
 log.info(log_summary())
 
 if (params.help) {
-    exit 1
-}
-
-if (workflow.profile == "") {
-    println "Must set -profile: local, quest, gcp"
     exit 1
 }
 

--- a/main.nf
+++ b/main.nf
@@ -33,12 +33,12 @@ if (params.debug.toString() == "true") {
     params.output = "release-debug"
     params.sample_sheet = "${workflow.projectDir}/test_data/sample_sheet.tsv"
     params.bam_location = "${workflow.projectDir}" // Use this to specify the directory for bams
-    params.cendr = true  // Whether write out strain vcf and severity tracks which is likely only used by cendr
+//    params.cendr = true  // Whether write out strain vcf and severity tracks which is likely only used by cendr
 } else {
     // The strain sheet that used for 'production' is located in the root of the git repo
     params.output = "WI-${date}"
     params.sample_sheet = "${workflow.projectDir}/sample_sheet.tsv"
-    params.cendr = false
+//    params.cendr = false
 }
 
 
@@ -51,8 +51,7 @@ params.fisherstrand = 100.0
 params.high_missing = 0.95
 params.high_heterozygosity = 0.10
 
-// Variant annotation
-params.vcfanno_config = "data/vcfanno.toml"
+
 
 def log_summary() {
 
@@ -126,8 +125,8 @@ sample_sheet = Channel.fromPath(params.sample_sheet, checkIfExists: true)
                                         row.bam = "${params.bam_location}/${row.bam}"
                                     }           
                                     [row.strain,
-                                     file("${row.bam}", checkExists: true),
-                                     file("${row.bam}.bai", checkExists: true)] }
+                                     file("${row.bam}", checkIfExists: true),
+                                     file("${row.bam}.bai", checkIfExists: true)] }
 
 
 workflow {
@@ -157,39 +156,17 @@ workflow {
                         import_genomics_db | \
                         genotype_cohort_gvcf_db
 
-    // Combine VCF anno config and send to annotation
-    genotype_cohort_gvcf_db.out
-        .combine(Channel.fromPath(params.vcfanno_config))
-        .combine(Channel.fromPath(params.dust_bed))
-        .combine(Channel.fromPath(params.dust_bed + ".tbi"))
-        .combine(Channel.fromPath(params.repeat_masker_bed))
-        .combine(Channel.fromPath(params.repeat_masker_bed + ".tbi")) | annotate_vcf
 
-    vcfs = annotate_vcf.out.anno_vcf.collect().map { [it] }.combine(get_contigs.out)
+    // Combine VCF and filter
+    vcfs = genotype_cohort_gvcf_db.out.collect().map { [it] }.combine(get_contigs.out)
     vcfs | concatenate_vcf
     concatenate_vcf.out.vcf | soft_filter
     soft_filter.out.soft_filter_vcf.combine(get_contigs.out) | hard_filter
 
-if (params.cendr == true) {
-
-      // Generate Strain-level TSV and VCFs
-      soft_filter.out.soft_filter_vcf | strain_list
-      strain_set = strain_list.out.splitText()
-                     .map { it.trim() }
-
-      strain_set.combine( soft_filter.out.soft_filter_vcf ) | generate_strain_tsv
-      
-      // Extract SNPeff severity tracks
-      mod_tracks = Channel.from(["LOW", "MODERATE", "HIGH", "MODIFIER"])
-      soft_filter.out.soft_filter_vcf.spread(mod_tracks) | generate_severity_tracks
-
-}
-
 
     // MultiQC Report
     soft_filter.out.soft_vcf_stats.concat(
-        hard_filter.out.hard_vcf_stats,
-        annotate_vcf.out.snpeff_csv
+        hard_filter.out.hard_vcf_stats
     ).collect() | multiqc_report
 
 }
@@ -373,49 +350,6 @@ process genotype_cohort_gvcf_db {
     """
 }
 
-/*=====================================================
-~ ~ ~ > *  SnpEff Annotate Cohort Chrom VCFs  * < ~ ~ ~  
-=====================================================*/
-
-process annotate_vcf {
-
-    label 'lg' 
-    
-    tag { contig }
-
-    input:
-        tuple val(contig), \
-              file("${contig}.bcf"), \
-              file("${contig}.bcf.csi"), \
-              path(vcfanno), \
-              path("dust.bed.gz"), \
-              path("dust.bed.gz.tbi"), \
-              path("repeat_masker.bed.gz"), \
-              path("repeat_masker.bed.gz.tbi")
-
-    output:
-        tuple path("${contig}.annotated.vcf.gz"), path("${contig}.annotated.vcf.gz.tbi"), emit: 'anno_vcf'
-        path "${contig}.${date}.snpeff.csv", emit: 'snpeff_csv'
-
-
-    script:
-    """
-        bcftools view -O v --min-af 0.000001 --threads=${task.cpus-1} ${contig}.bcf | \\
-        vcffixup - | \\
-        snpEff eff -csvStats ${contig}.${date}.snpeff.csv \\
-                   -no-downstream \\
-                   -no-intergenic \\
-                   -no-upstream \\
-                   -nodownload \\
-        -dataDir ${params.snpeff_dir} \\
-        -config ${params.snpeff_dir}/snpEff.config \\
-        ${params.snpeff_reference} | \\
-        bcftools view --threads=${task.cpus-1} -O z > out.vcf.gz
-        vcfanno ${vcfanno} out.vcf.gz | bcftools view -O z > ${contig}.annotated.vcf.gz
-        bcftools index --tbi ${contig}.annotated.vcf.gz
-    """
-
-}
 
 /*===============================================
 ~ ~ ~ > *   Concatenate Annotated VCFs  * < ~ ~ ~
@@ -432,9 +366,9 @@ process concatenate_vcf {
         tuple path("WI.annotated.vcf.gz"), path("WI.annotated.vcf.gz.tbi"), emit: 'vcf'
 
     """
-        awk '{ print \$0 ".annotated.vcf.gz" }' contigs.txt > contig_set.tsv
-        bcftools concat  -O z --file-list contig_set.tsv > WI.annotated.vcf.gz
-        bcftools index --tbi WI.annotated.vcf.gz
+        awk '{ print \$0 "_cohort.bcf" }' contigs.txt > contig_set.tsv
+        bcftools concat  -O z --file-list contig_set.tsv > WI.raw.vcf.gz
+        bcftools index --tbi WI.raw.vcf.gz
     """
 }
 
@@ -501,11 +435,6 @@ process soft_filter {
 ==============================================*/
 
 process hard_filter {
-    /*
-        !! Important
-        CSQ Annotations take place after hard filtering because they create a haplotype-based prediction.
-        THerefore, it is essential that poor-quality variants are removed.
-    */
 
 
     label 'lg'
@@ -556,16 +485,9 @@ process hard_filter {
 
         parallel --verbose generate_hard_filter :::: ${contigs}
 
-        # Remove transposons from GFF3 as they throw errors with CSQ
-        gzip -dc ${file(params.csq_gff, checkIfExists: true)} | grep -v 'transposon' | bgzip > csq.gff.gz
-        tabix -p gff csq.gff.gz
-
 
         awk '{ print \$0 ".vcf.gz" }' ${contigs} > contig_set.tsv
-        bcftools concat  -O u --file-list contig_set.tsv | \\
-        bcftools csq -O z --fasta-ref ${reference} \\
-                     --gff-annot csq.gff.gz \\
-                     --phase a > WI.${date}.hard-filter.vcf.gz
+        bcftools concat  -O z --file-list contig_set.tsv > WI.${date}.hard-filter.vcf.gz
 
         bcftools index WI.${date}.hard-filter.vcf.gz
         bcftools index --tbi WI.${date}.hard-filter.vcf.gz
@@ -573,79 +495,8 @@ process hard_filter {
     """
 }
 
-process strain_list {
-
-    input:
-        tuple path(vcf), path(vcf_index)
-    
-    output:
-        file("samples.txt")
-
-    """
-        bcftools query --list-samples ${vcf} > samples.txt
-    """
-}
 
 
-process generate_strain_tsv {
-    // Generate a single TSV and VCF for every strain.
-
-    tag { strain }
-
-    publishDir "${params.output}/strain/tsv", mode: 'copy', pattern: "*.tsv.gz*"
-
-    input:
-        tuple val(strain), path(vcf), file(vcf_index)
-
-    output:
-        tuple path("${strain}.${date}.tsv.gz"),  path("${strain}.${date}.tsv.gz.tbi")
-
-    """
-        # Generate TSV
-        {
-            echo -e 'CHROM\\tPOS\\tREF\\tALT\\tFILTER\\tFT\\tGT';
-            bcftools query -f '[%CHROM\t%POS\t%REF\t%ALT\t%FILTER\t%FT\t%TGT]\n' --samples ${strain} ${vcf};
-        } | awk -F'\\t' -vOFS='\\t' '{ gsub("\\\\.", "PASS", \$6) ; print }' > ${strain}.${date}.tsv
-
-        bgzip ${strain}.${date}.tsv
-        tabix -S 1 -s 1 -b 2 -e 2 ${strain}.${date}.tsv.gz
-    """
-
-}
-
-process generate_severity_tracks {
-    /*
-        The severity tracks are bedfiles with annotations for
-        LOW
-        MODERATE
-        HIGH
-        MODIFIER
-        variants as annotated with SNPEff
-
-        They are used on the CeNDR browser.
-    */
-
-    publishDir "${params.output}/tracks", mode: 'copy'
-
-    tag { severity }
-
-    input:
-        tuple path("in.vcf.gz"), path("in.vcf.gz.csi"), val(severity)
-    output:
-        set file("${date}.${severity}.bed.gz"), file("${date}.${severity}.bed.gz.tbi")
-
-    """
-        bcftools view --apply-filters PASS in.vcf.gz | \
-        grep ${severity} | \
-        awk '\$0 !~ "^#" { print \$1 "\\t" (\$2 - 1) "\\t" (\$2)  "\\t" \$1 ":" \$2 "\\t0\\t+"  "\\t" \$2 - 1 "\\t" \$2 "\\t0\\t1\\t1\\t0" }' | \\
-        bgzip  > ${date}.${severity}.bed.gz
-        tabix -p bed ${date}.${severity}.bed.gz
-        fsize=\$(zcat ${date}.${severity}.bed.gz | wc -c)
-        if [ \${fsize} -lt 2000 ]; then
-            exit 1
-        fi;
-    """
-}
 
 process multiqc_report {
 


### PR DESCRIPTION
- Removed all annotation steps (move into post-gatk-nf)
- Removed cendr specific steps: generate severity tracks and single-strain vcf/tsv (move into post-gatk-nf)
- Formatted help section the same as trim-fq-nf and alignment-nf